### PR TITLE
fix: update deprecated diagnostic argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-locals {
-  diagnostic_setting_metric_categories = ["AllMetrics"]
-}
-
 resource "azurerm_public_ip" "this" {
   name                = var.address_name
   resource_group_name = var.resource_group_name
@@ -32,7 +28,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   }
 
   dynamic "enabled_metric" {
-    for_each = toset(concat(local.diagnostic_setting_metric_categories, var.diagnostic_setting_enabled_metric_categories))
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
 
     content {
       # Azure expects explicit configuration of both enabled and disabled metric categories.

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
 
     content {
       # Azure expects explicit configuration of both enabled and disabled metric categories.
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,6 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     content {
       # Azure expects explicit configuration of both enabled and disabled metric categories.
       category = metric.value
-      enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     }
   }
 
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = toset(concat(local.diagnostic_setting_metric_categories, var.diagnostic_setting_enabled_metric_categories))
 
     content {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.39.0"
+      version = ">= 4.31.0"
     }
   }
 }


### PR DESCRIPTION
- Renamed `metric` argument to `enabled-metric`
- Removed `enabled` argument as this is no longer valid.

Argument `metric` has been deprecated in favor of the `enabled_metric` property and will be removed in v5.0 of the AzureRM provider.